### PR TITLE
Base Url Updated

### DIFF
--- a/Frontend/src/Globle.ts
+++ b/Frontend/src/Globle.ts
@@ -1,7 +1,7 @@
 // old export const BACKEND_URL = "https://importexport.udhyog4.co.in/api/v1"
-export const BACKEND_URL = "https://api.prikriti.co.in/v1"
-// export const BACKEND_URL = "http://localhost:3000/api/v1"
+// export const BACKEND_URL = "https://api.prikriti.co.in/v1"
+export const BACKEND_URL = "http://localhost:3000/api/v1"
 
 // old export const Websocket_URL = "wss://importexport.udhyog4.co.in/api/socket"
-export const Websocket_URL = "https://api.prikriti.co.in/socket"
-// export const Websocket_URL = "ws://localhost:3000/api/socket"
+// export const Websocket_URL = "https://api.prikriti.co.in/socket"
+export const Websocket_URL = "ws://localhost:3000/api/socket"

--- a/Frontend/src/components/DocumentManagementModal.tsx
+++ b/Frontend/src/components/DocumentManagementModal.tsx
@@ -208,7 +208,8 @@ const DocumentManagementModal: React.FC<DocumentModalProps> = ({
 
   const getDocumentUrl = (documentUrl: string) => {
     // Remove /api/v1 from BACKEND_URL for document access since document URLs already include /api/uploads
-    const baseUrl = BACKEND_URL.replace('/api/v1', '');
+    const baseUrl1 = BACKEND_URL.replace('/api/v1', '');
+    const baseUrl = baseUrl1.replace('/v1', '');
     return `${baseUrl}${documentUrl}`;
   };
 


### PR DESCRIPTION
This pull request updates the backend and websocket URLs in `Globle.ts` to use local development endpoints, and fixes a bug in the document URL generation logic in `DocumentManagementModal.tsx` to more robustly remove API version suffixes from the base URL.

**Environment configuration changes:**

* Switched `BACKEND_URL` and `Websocket_URL` in `Globle.ts` to use local development endpoints (`localhost:3000`) instead of the production URLs.

**Bug fix:**

* Improved the logic in `getDocumentUrl` within `DocumentManagementModal.tsx` to ensure both `/api/v1` and `/v1` are removed from `BACKEND_URL` when generating document URLs, preventing malformed URLs in different environments.